### PR TITLE
Add hdgaming_app Flutter skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# Hdgaming-app
+# Hdgaming-app Repository
+
+This repository contains the `hdgaming_app` Flutter project.

--- a/hdgaming_app/android/README.md
+++ b/hdgaming_app/android/README.md
@@ -1,0 +1,1 @@
+Placeholder for Android platform

--- a/hdgaming_app/ios/README.md
+++ b/hdgaming_app/ios/README.md
@@ -1,0 +1,1 @@
+Placeholder for iOS platform

--- a/hdgaming_app/lib/main.dart
+++ b/hdgaming_app/lib/main.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Hdgaming App',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatelessWidget {
+  const MyHomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Hdgaming App'),
+      ),
+      body: const Center(
+        child: Text('Welcome to Hdgaming App'),
+      ),
+    );
+  }
+}

--- a/hdgaming_app/pubspec.yaml
+++ b/hdgaming_app/pubspec.yaml
@@ -1,0 +1,19 @@
+name: hdgaming_app
+description: A new Flutter project.
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/hdgaming_app/web/README.md
+++ b/hdgaming_app/web/README.md
@@ -1,0 +1,1 @@
+Placeholder for web platform


### PR DESCRIPTION
## Summary
- add README describing repository
- create `hdgaming_app` with minimal Flutter structure
- include placeholder platform directories for Android, iOS and web

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6851b5daf8008320b8c5de1fc8938610