### PR TITLE
Add Firebase messaging with overlay notifications

### DIFF
--- a/hdgaming_app/lib/auth_cubit.dart
+++ b/hdgaming_app/lib/auth_cubit.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+
+part 'auth_state.dart';
+
+class AuthCubit extends Cubit<AuthState> {
+  AuthCubit({
+    required String baseUrl,
+    FlutterSecureStorage? storage,
+    http.Client? httpClient,
+  })  : _baseUrl = baseUrl,
+        _storage = storage ?? const FlutterSecureStorage(),
+        _client = httpClient ?? http.Client(),
+        super(const AuthState.unknown());
+
+  final String _baseUrl;
+  final FlutterSecureStorage _storage;
+  final http.Client _client;
+
+  static const _tokenKey = 'jwt_token';
+
+  String? get token => state.token;
+
+  Uri _endpoint(String path) => Uri.parse('$_baseUrl$path');
+
+  Future<void> loadSession() async {
+    final token = await _storage.read(key: _tokenKey);
+    if (token != null) {
+      emit(AuthState.authenticated(token));
+    } else {
+      emit(const AuthState.unauthenticated());
+    }
+  }
+
+  Future<void> login(String email, String password) async {
+    emit(const AuthState.loading());
+    try {
+      final response = await _client.post(
+        _endpoint('/wp-json/jwt-auth/v1/token'),
+        body: {'username': email, 'password': password},
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final token = data['token'] as String?;
+        if (token != null) {
+          await _storage.write(key: _tokenKey, value: token);
+          emit(AuthState.authenticated(token));
+          return;
+        }
+      }
+      emit(const AuthState.unauthenticated());
+    } catch (_) {
+      emit(const AuthState.unauthenticated());
+    }
+  }
+
+  Future<void> register(String email, String password) async {
+    emit(const AuthState.loading());
+    try {
+      final response = await _client.post(
+        _endpoint('/wp-json/wp/v2/users/register'),
+        body: {'email': email, 'password': password},
+      );
+      if (response.statusCode == 200) {
+        await login(email, password);
+        return;
+      }
+      emit(const AuthState.unauthenticated());
+    } catch (_) {
+      emit(const AuthState.unauthenticated());
+    }
+  }
+
+  Future<void> logout() async {
+    await _storage.delete(key: _tokenKey);
+    emit(const AuthState.unauthenticated());
+  }
+}

--- a/hdgaming_app/lib/auth_state.dart
+++ b/hdgaming_app/lib/auth_state.dart
@@ -1,0 +1,20 @@
+part of 'auth_cubit.dart';
+
+enum AuthStatus { unknown, loading, authenticated, unauthenticated }
+
+class AuthState extends Equatable {
+  final AuthStatus status;
+  final String? token;
+
+  const AuthState._({required this.status, this.token});
+
+  const AuthState.unknown() : this._(status: AuthStatus.unknown);
+  const AuthState.loading() : this._(status: AuthStatus.loading);
+  const AuthState.unauthenticated()
+      : this._(status: AuthStatus.unauthenticated);
+  const AuthState.authenticated(String token)
+      : this._(status: AuthStatus.authenticated, token: token);
+
+  @override
+  List<Object?> get props => [status, token];
+}

--- a/hdgaming_app/lib/category_drawer.dart
+++ b/hdgaming_app/lib/category_drawer.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class CategoryDrawer extends StatefulWidget {
+  final List<String> categories;
+  final ValueChanged<int>? onCategorySelected;
+
+  const CategoryDrawer({Key? key, required this.categories, this.onCategorySelected}) : super(key: key);
+
+  @override
+  State<CategoryDrawer> createState() => _CategoryDrawerState();
+}
+
+class _CategoryDrawerState extends State<CategoryDrawer> {
+  int _selectedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView.builder(
+        itemCount: widget.categories.length,
+        itemBuilder: (context, index) {
+          final selected = index == _selectedIndex;
+          return InkWell(
+            onTap: () {
+              setState(() {
+                _selectedIndex = index;
+              });
+              widget.onCategorySelected?.call(index);
+            },
+            child: Container(
+              color: selected ? Colors.grey.shade200 : Colors.transparent,
+              child: Row(
+                children: [
+                  Container(
+                    width: 4,
+                    height: 48,
+                    color: selected ? Colors.red : Colors.transparent,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 16.0),
+                      child: Text(widget.categories[index]),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/hdgaming_app/lib/checkout_page.dart
+++ b/hdgaming_app/lib/checkout_page.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_stripe/flutter_stripe.dart';
+import 'package:http/http.dart' as http;
+
+class CheckoutPage extends StatefulWidget {
+  const CheckoutPage({Key? key}) : super(key: key);
+
+  @override
+  State<CheckoutPage> createState() => _CheckoutPageState();
+}
+
+class _CheckoutPageState extends State<CheckoutPage> {
+  bool _loading = false;
+
+  Future<void> _startCheckout() async {
+    setState(() => _loading = true);
+    try {
+      final response = await http.post(
+        Uri.parse('https://example.com/wp-json/wc/v3/payment_intents'),
+      );
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final clientSecret = data['client_secret'] as String;
+      await Stripe.instance.initPaymentSheet(
+        paymentSheetParameters: SetupPaymentSheetParameters(
+          paymentIntentClientSecret: clientSecret,
+          merchantDisplayName: 'Hdgaming',
+        ),
+      );
+      await Stripe.instance.presentPaymentSheet();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Payment complete')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Checkout')),
+      body: Center(
+        child: _loading
+            ? const CircularProgressIndicator()
+            : ElevatedButton(
+                onPressed: _startCheckout,
+                child: const Text('Pay Now'),
+              ),
+      ),
+    );
+  }
+}

--- a/hdgaming_app/lib/main.dart
+++ b/hdgaming_app/lib/main.dart
@@ -1,7 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:overlay_support/overlay_support.dart';
+import 'category_drawer.dart';
+import 'product_detail_page.dart';
 
-void main() {
-  runApp(const MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  await _initMessaging();
+  runApp(const OverlaySupport.global(child: MyApp()));
+}
+
+Future<void> _initMessaging() async {
+  final messaging = FirebaseMessaging.instance;
+  await messaging.requestPermission();
+  FirebaseMessaging.onMessage.listen(_showMessageOverlay);
+}
+
+void _showMessageOverlay(RemoteMessage message) {
+  showOverlayNotification(
+    (context) {
+      final title = message.notification?.title ?? 'Notification';
+      final body = message.notification?.body ?? '';
+      return Material(
+        color: Colors.black,
+        child: SafeArea(
+          bottom: false,
+          child: ListTile(
+            title: Text(title, style: const TextStyle(color: Colors.red)),
+            subtitle: Text(body, style: const TextStyle(color: Colors.white)),
+          ),
+        ),
+      );
+    },
+    duration: const Duration(seconds: 3),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -19,17 +53,60 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyHomePage extends StatelessWidget {
+class MyHomePage extends StatefulWidget {
   const MyHomePage({Key? key}) : super(key: key);
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  final List<String> _categories = [
+    'Home',
+    'Action',
+    'Adventure',
+    'RPG',
+    'Sports',
+  ];
+  int _selectedIndex = 0;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Hdgaming App'),
+      drawer: CategoryDrawer(
+        categories: _categories,
+        onCategorySelected: (index) {
+          setState(() {
+            _selectedIndex = index;
+          });
+          Navigator.pop(context);
+        },
       ),
-      body: const Center(
-        child: Text('Welcome to Hdgaming App'),
+      appBar: AppBar(
+        title: Text(_categories[_selectedIndex]),
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const ProductDetailPage(
+                  imageUrls: [
+                    'https://via.placeholder.com/300.png',
+                    'https://via.placeholder.com/300.png?text=2',
+                  ],
+                  description: 'Questo è un prodotto di esempio.',
+                  faq: [
+                    'Domanda 1: risposta',
+                    'Domanda 2: risposta',
+                  ],
+                ),
+              ),
+            );
+          },
+          child: const Text('Open Product'),
+        ),
       ),
     );
   }

--- a/hdgaming_app/lib/product_detail_page.dart
+++ b/hdgaming_app/lib/product_detail_page.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'checkout_page.dart';
+
+class ProductDetailPage extends StatefulWidget {
+  final List<String> imageUrls;
+  final String description;
+  final List<String> faq;
+
+  const ProductDetailPage({
+    Key? key,
+    required this.imageUrls,
+    required this.description,
+    required this.faq,
+  }) : super(key: key);
+
+  @override
+  State<ProductDetailPage> createState() => _ProductDetailPageState();
+}
+
+class _ProductDetailPageState extends State<ProductDetailPage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  void _openCheckout() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const CheckoutPage()),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Product Details'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Descrizione'),
+            Tab(text: 'FAQ'),
+          ],
+        ),
+      ),
+      body: Column(
+        children: [
+          SizedBox(
+            height: 250,
+            child: PageView.builder(
+              itemCount: widget.imageUrls.length,
+              itemBuilder: (context, index) {
+                final url = widget.imageUrls[index];
+                return CachedNetworkImage(
+                  imageUrl: url,
+                  fit: BoxFit.cover,
+                  placeholder: (context, url) =>
+                      const Center(child: CircularProgressIndicator()),
+                  errorWidget: (context, url, error) =>
+                      const Icon(Icons.error),
+                );
+              },
+            ),
+          ),
+          Expanded(
+            child: TabBarView(
+              controller: _tabController,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(widget.description),
+                ),
+                ListView.builder(
+                  padding: const EdgeInsets.all(16.0),
+                  itemCount: widget.faq.length,
+                  itemBuilder: (context, index) {
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 8.0),
+                      child: Text('• ${widget.faq[index]}'),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+          _AnimatedAddToCartButton(onPressed: _openCheckout),
+        ],
+      ),
+    );
+  }
+}
+
+class _AnimatedAddToCartButton extends StatefulWidget {
+  final VoidCallback onPressed;
+  const _AnimatedAddToCartButton({required this.onPressed});
+
+  @override
+  State<_AnimatedAddToCartButton> createState() =>
+      _AnimatedAddToCartButtonState();
+}
+
+class _AnimatedAddToCartButtonState extends State<_AnimatedAddToCartButton> {
+  bool _added = false;
+
+  void _handleTap() {
+    setState(() {
+      _added = !_added;
+    });
+    widget.onPressed();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 300),
+        height: 48,
+        decoration: BoxDecoration(
+          color: Colors.red,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: _handleTap,
+            borderRadius: BorderRadius.circular(8),
+            child: Center(
+              child: Text(
+                _added ? 'Added' : 'Add to Cart',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/hdgaming_app/pubspec.yaml
+++ b/hdgaming_app/pubspec.yaml
@@ -10,6 +10,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  cached_network_image: ^3.2.3
+  flutter_stripe: ^9.3.0
+  http: ^0.13.5
+  flutter_bloc: ^8.1.1
+  equatable: ^2.0.5
+  flutter_secure_storage: ^8.0.0
+  firebase_core: ^2.4.1
+  firebase_messaging: ^14.3.0
+  overlay_support: ^2.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- integrate `firebase_messaging` and `overlay_support`
- init Firebase and messaging on launch
- show red-on-black overlay notification when a message arrives

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ee3292e483209ff47f36999f302a